### PR TITLE
put the db creation before the check to avoid the error 

### DIFF
--- a/secfsdstools/c_update/updateprocess.py
+++ b/secfsdstools/c_update/updateprocess.py
@@ -142,7 +142,9 @@ class Updater:
         Returns:
 
         """
-
+        # create db if necessary
+        DbCreator(db_dir=self.db_dir).create_db()
+        
         if not self._check_for_update():
             LOGGER.debug(
                 'Skipping update: last check was done less than %d seconds ago',
@@ -150,8 +152,7 @@ class Updater:
             return
 
         LOGGER.info('Check if new report zip files are available...')
-        # create db if necessary
-        DbCreator(db_dir=self.db_dir).create_db()
+        
 
         # execute the update logic
         self._update()


### PR DESCRIPTION
When i used the library, it did not worked for me.

I get error about database not existing.

I believe it comes from the fact you create the DB only after the check for update. It works if the DB is already existing but not when you do initial update (at least for me). 

So I propose this change.

I am sorry I did not open an issue about the topic (but I needed a quick fix). 