### PR TITLE
Update secdownloading.py to new archive URL for SEC financial markets…

### DIFF
--- a/secfsdstools/c_download/secdownloading.py
+++ b/secfsdstools/c_download/secdownloading.py
@@ -16,7 +16,7 @@ class SecZipDownloader(BaseDownloader):
     """
         Downloading the quarterly zip files of the financial statement data sets
     """
-    FIN_STAT_DATASET_URL = 'https://www.sec.gov/dera/data/financial-statement-data-sets.html'
+    FIN_STAT_DATASET_URL = 'https://www.sec.gov/data-research/sec-markets-data/financial-statement-data-sets-archive'
 
     table_re = re.compile('<TABLE.*?>.*</TABLE>', re.IGNORECASE + re.MULTILINE + re.DOTALL)
     href_re = re.compile("href=\".*?\"", re.IGNORECASE + re.MULTILINE + re.DOTALL)


### PR DESCRIPTION
The SEC has changed its landing page and structure for the financial statement data sets. They have retained the old landing page and datasets at an archive URL. I've just updated to this URL but it appears the data in this old structure will no longer be updated. This gets the package back to running as original designed at least for the time being.